### PR TITLE
fix iOS 8-bit issue

### DIFF
--- a/ios/RNAudioRecord.m
+++ b/ios/RNAudioRecord.m
@@ -9,12 +9,13 @@ RCT_EXPORT_METHOD(init:(NSDictionary *) options) {
     _recordState.mDataFormat.mSampleRate        = options[@"sampleRate"] == nil ? 44100 : [options[@"sampleRate"] doubleValue];
     _recordState.mDataFormat.mBitsPerChannel    = options[@"bitsPerSample"] == nil ? 16 : [options[@"bitsPerSample"] unsignedIntValue];
     _recordState.mDataFormat.mChannelsPerFrame  = options[@"channels"] == nil ? 1 : [options[@"channels"] unsignedIntValue];
-    _recordState.mDataFormat.mBytesPerPacket    = _recordState.mDataFormat.mChannelsPerFrame * sizeof (SInt16);
-    _recordState.mDataFormat.mBytesPerFrame     = _recordState.mDataFormat.mChannelsPerFrame * sizeof (SInt16);
+    _recordState.mDataFormat.mBytesPerPacket    = (_recordState.mDataFormat.mBitsPerChannel / 8) * _recordState.mDataFormat.mChannelsPerFrame;
+    _recordState.mDataFormat.mBytesPerFrame     = _recordState.mDataFormat.mBytesPerPacket;
     _recordState.mDataFormat.mFramesPerPacket   = 1;
     _recordState.mDataFormat.mReserved          = 0;
     _recordState.mDataFormat.mFormatID          = kAudioFormatLinearPCM;
-    _recordState.mDataFormat.mFormatFlags       = kLinearPCMFormatFlagIsSignedInteger | kLinearPCMFormatFlagIsPacked;
+    _recordState.mDataFormat.mFormatFlags       = _recordState.mDataFormat.mBitsPerChannel == 8 ? kLinearPCMFormatFlagIsPacked : (kLinearPCMFormatFlagIsSignedInteger | kLinearPCMFormatFlagIsPacked);
+
     
     _recordState.bufferByteSize = 2048;
     _recordState.mSelf = self;


### PR DESCRIPTION
WAV 8-bit data is unsigned, while 16-bit data is signed. So use only `kAudioFormatFlagIsPacked` flag for 8-bit in iOS. Otherwise `AudioFileCreateWithURL` will fail with `SetDataFormat failed` error.

Fixes #2 