### PR TITLE
Resolve promise of the stop method just after creating the audio file

### DIFF
--- a/android/src/main/java/com/goodatlas/audiorecord/RNAudioRecordModule.java
+++ b/android/src/main/java/com/goodatlas/audiorecord/RNAudioRecordModule.java
@@ -118,7 +118,7 @@ public class RNAudioRecordModule extends ReactContextBaseJavaModule {
                     recorder.stop();
                     os.close();
                     saveAsWav();
-                    if(stopRecordingPromise)
+                    if(stopRecordingPromise != null)
                          stopRecordingPromise.resolve(outFile);
                 } catch (Exception e) {
                     e.printStackTrace();


### PR DESCRIPTION
en:

Resolve promise of the "stop" method just after creating the audio file, synchronized methods.
This modification is due to the need to have the audio file created just after obtaining the uri of it in the "stop" method.
Since we need to send the file to a remote server.
Currently the dependency delivers the file uri and then creates the file.

es:

Resolver promesa del metodo "stop" justo despues de crear el archivo de audio, metodos sincronizados.
Esta modificacion es debido a la necesidad de tener el archivo de audio creado justo despues de obtener la uri del mismo en el metodo "stop".
Ya que necesitamos enviar el archivo a un servidor remoto.
Actualmente la dependencia entrega la uri del archivo y luego crea el archivo.