### PR TITLE
Correct type definition for `.on`

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,9 +1,11 @@
+import { EmitterSubscription } from 'react-native';
+
 declare module "react-native-audio-record" {
   export interface IAudioRecord {
     init: (options: Options) => void
     start: () => void
     stop: () => Promise<string>
-    on: (event: "data", callback: (data: string) => void) => void
+    on: (event: "data", callback: (data: string) => void) => EmitterSubscription
   }
 
   export interface Options {


### PR DESCRIPTION
In the JavaScript, .on actually returns an EmitterSubscription rather than void. This is important mainly because you can call .remove on it.