### PR TITLE
fix native event emitter warnings

### DIFF
--- a/android/src/main/java/com/goodatlas/audiorecord/RNAudioRecordModule.java
+++ b/android/src/main/java/com/goodatlas/audiorecord/RNAudioRecordModule.java
@@ -48,6 +48,16 @@ public class RNAudioRecordModule extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
+    public void addListener(String eventName) {
+        // Keep: Required for RN built in Event Emitter Calls.
+    }
+
+    @ReactMethod
+    public void removeListeners(Integer count) {
+        // Keep: Required for RN built in Event Emitter Calls.
+    }
+
+    @ReactMethod
     public void init(ReadableMap options) {
         sampleRateInHz = 44100;
         if (options.hasKey("sampleRate")) {


### PR DESCRIPTION
Fix for the warnings below:

```
 `new NativeEventEmitter()` was called with a non-null argument without the required `addListener` method.
 `new NativeEventEmitter()` was called with a non-null argument without the required `removeListeners` method.
```
Following resolution frrom [react-native-firebase](https://github.com/invertase/react-native-firebase/pull/5616/files#diff-c887076b0c80d540aed1bfbb472cc8f20516634e8e72d53014c65d690bba4fb1)
