### PR TITLE
fix audio session add play

### DIFF
--- a/ios/RNAudioRecord.m
+++ b/ios/RNAudioRecord.m
@@ -30,7 +30,8 @@ RCT_EXPORT_METHOD(start) {
 
     // most audio players set session category to "Playback", record won't work in this mode
     // therefore set session category to "Record" before recording
-    [[AVAudioSession sharedInstance] setCategory:AVAudioSessionCategoryRecord error:nil];
+    // use AVAudioSessionCategoryPlayAndRecord to be able to play a sound after
+    [[AVAudioSession sharedInstance] setCategory:AVAudioSessionCategoryPlayAndRecord error:nil];
 
     _recordState.mIsRunning = true;
     _recordState.mCurrentPacket = 0;

--- a/ios/RNAudioRecord.m
+++ b/ios/RNAudioRecord.m
@@ -31,7 +31,7 @@ RCT_EXPORT_METHOD(start) {
     // most audio players set session category to "Playback", record won't work in this mode
     // therefore set session category to "Record" before recording
     // use AVAudioSessionCategoryPlayAndRecord to be able to play a sound after
-    [[AVAudioSession sharedInstance] setCategory:AVAudioSessionCategoryPlayAndRecord error:nil];
+    [[AVAudioSession sharedInstance] setCategory:AVAudioSessionCategoryPlayAndRecord withOptions:AVAudioSessionCategoryOptionDefaultToSpeaker error:nil];
 
     _recordState.mIsRunning = true;
     _recordState.mCurrentPacket = 0;


### PR DESCRIPTION
On iOS, use `AVAudioSessionCategoryPlayAndRecord` audio session to be able to play sound after record.